### PR TITLE
typed access to .widget, .state, .data with more generics

### DIFF
--- a/example/lib/counter_advanced.dart
+++ b/example/lib/counter_advanced.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tasteful/tasteful.dart';
 
-class CounterAdvanced extends TastefulWidget<int> {
+class CounterAdvanced extends TastefulWidget<int, CounterState> {
   const CounterAdvanced({required this.title});
 
   final String title;
@@ -13,8 +13,7 @@ class CounterAdvanced extends TastefulWidget<int> {
   CounterState createState() => CounterState();
 
   @override
-  Widget build(TastefulBuildContext context) {
-    final CounterState state = context.state as CounterState;
+  Widget build(context) {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
@@ -30,7 +29,7 @@ class CounterAdvanced extends TastefulWidget<int> {
             Text(
               '${context.data}',
               style: Theme.of(context).textTheme.headlineMedium!.copyWith(
-                color: state._colorAnimation.value,
+                color: context.state._colorAnimation.value,
               ),
             ),
           ],
@@ -47,12 +46,14 @@ class CounterAdvanced extends TastefulWidget<int> {
   }
 }
 
-class CounterState extends TastefulState<int> with SingleTickerProviderStateMixin {
+class CounterState extends TastefulState<int, CounterAdvanced> with SingleTickerProviderStateMixin {
   late AnimationController _controller;
   late Animation<Color?> _colorAnimation;
 
   @override
   void initState() {
+    widget.title; // test typed widget access
+    data++;  // test typed data access
     super.initState();
     _controller = AnimationController(
       duration: Duration(seconds: 2),

--- a/example/lib/counter_dataless.dart
+++ b/example/lib/counter_dataless.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tasteful/tasteful.dart';
 
-class CounterDataless extends TastefulWidget<void> {
+class CounterDataless extends TastefulWidget<void, CounterState> {
   const CounterDataless({required this.title});
 
   final String title;
@@ -10,8 +10,7 @@ class CounterDataless extends TastefulWidget<void> {
   CounterState createState() => CounterState();
 
   @override
-  Widget build(TastefulBuildContext context) {
-    final CounterState state = context.state as CounterState;
+  Widget build(context) {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
@@ -25,9 +24,9 @@ class CounterDataless extends TastefulWidget<void> {
               'You have pushed the button this many times:',
             ),
             Text(
-              '${state.count}',
+              '${context.state.count}',
               style: Theme.of(context).textTheme.headlineMedium!.copyWith(
-                color: state._colorAnimation.value,
+                color: context.state._colorAnimation.value,
               ),
             ),
           ],
@@ -35,7 +34,7 @@ class CounterDataless extends TastefulWidget<void> {
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
-          state.count++;
+          context.state.count++;
         },
         tooltip: 'Increment',
         child: const Icon(Icons.add),
@@ -44,7 +43,7 @@ class CounterDataless extends TastefulWidget<void> {
   }
 }
 
-class CounterState extends TastefulState<void> with SingleTickerProviderStateMixin {
+class CounterState extends TastefulState<void, CounterDataless> with SingleTickerProviderStateMixin {
   late AnimationController _controller;
   late Animation<Color?> _colorAnimation;
 

--- a/example/lib/counter_stateful.dart
+++ b/example/lib/counter_stateful.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tasteful/tasteful.dart';
 
-class CounterStateful extends TastefulWidget<int> {
+class CounterStateful extends TastefulWidget<int, VoidState> {
   const CounterStateful({required this.title});
 
   final String title;
@@ -10,7 +10,7 @@ class CounterStateful extends TastefulWidget<int> {
   int createData() => 0;
 
   @override
-  Widget build(TastefulBuildContext context) {
+  Widget build(TastefulBuildContext<int, VoidState> context) {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,

--- a/example/lib/counter_stateless.dart
+++ b/example/lib/counter_stateless.dart
@@ -7,7 +7,7 @@ class CounterStateless extends TastefulWidget {
   final String title;
 
   @override
-  Widget build(TastefulBuildContext context) {
+  Widget build(context) {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,7 +27,7 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class Demos extends TastefulWidget<String> {
+class Demos extends TastefulWidget<String, VoidState> {
   const Demos({required this.title});
 
   final String title;
@@ -47,7 +47,7 @@ class Demos extends TastefulWidget<String> {
     };
   }
 
-  Widget _buildHome(TastefulBuildContext<String> context) {
+  Widget _buildHome(TastefulBuildContext<String, VoidState> context) {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,

--- a/test/tasteful_test.dart
+++ b/test/tasteful_test.dart
@@ -19,7 +19,7 @@ void main() {
   });
 }
 
-class Counter extends TastefulWidget<int> {
+class Counter extends TastefulWidget<int, VoidState> {
   Counter(this.greeting);
 
   final String greeting;


### PR DESCRIPTION
Add generics so that `this.widget`, `this.state`, and `this.data` had concrete return types.

HELP NEEDED: Is there a way to remove the need for `VoidState` without losing type safety and increasing type ceremony? 🤔 